### PR TITLE
Fix duration exception

### DIFF
--- a/SharpCast/Media.cs
+++ b/SharpCast/Media.cs
@@ -17,7 +17,7 @@
         public MediaMetadata Metadata { get; set; }
 
         [JsonProperty("duration")]
-        public double Duration { get; set; }
+        public double? Duration { get; set; }
 
         [JsonProperty("customData")]
         public Dictionary<string, string> CustomData { get; set; }


### PR DESCRIPTION
When a stream is buffering status returns null for a duration.